### PR TITLE
fix: Remove uncommented console.log

### DIFF
--- a/packages/codemirror-copilot/src/inline-suggestion.ts
+++ b/packages/codemirror-copilot/src/inline-suggestion.ts
@@ -119,7 +119,7 @@ export const fetchSuggestion = (fetchFn: InlineFetchFn) =>
         //     }
         // }
 
-        console.log("CH", update);
+        // console.log("CH", update);
         const result = await fetchFn(update.state);
         update.view.dispatch({
           effects: InlineSuggestionEffect.of({ text: result, doc: doc }),


### PR DESCRIPTION
This `console.log` statement makes it into the final package, which produces console output in apps. This PR just comments it out.