### PR TITLE
Fix a crash where codemirror.doc cannot be joined

### DIFF
--- a/packages/codemirror-copilot/src/copilot.ts
+++ b/packages/codemirror-copilot/src/copilot.ts
@@ -14,7 +14,7 @@ export const inlineCopilot = (
 ) => {
   const fetchSuggestion = async (state: EditorState) => {
     const { from, to } = state.selection.ranges[0];
-    const text = (state.doc as any).text.join("\n");
+    const text = state.doc.toString();
     const prefix = text.slice(0, to);
     const suffix = text.slice(from);
 


### PR DESCRIPTION
This fixes crashes that we've seen in prod, like `Cannot read properties of undefined (reading 'join')`. It tracks to this line:

https://github.com/asadm/codemirror-copilot/blob/main/packages/codemirror-copilot/src/copilot.ts#L17

Which is using an `as any`, and reading through how CodeMirror implements `doc.text`, seems like a lucky coincidence that this worked before. `toString()` does the same as what we're wanting to do here, but is a documented public method.