### PR TITLE
Fix website warning (className)

### DIFF
--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -1,12 +1,12 @@
-import CodeEditor from '@/components/editor'
-import { Landing } from '@/components/landing'
+import CodeEditor from "@/components/editor";
+import { Landing } from "@/components/landing";
 
 export default function Home() {
   return (
-    <div class="container mx-auto">
-    <Landing>
-      <CodeEditor />
-    </Landing>
+    <div className="container mx-auto">
+      <Landing>
+        <CodeEditor />
+      </Landing>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
Fixes a minor issue where the website had `class=` instead of `className=` for a prop.