### PR TITLE
Add docstrings to methods

### DIFF
--- a/packages/codemirror-copilot/src/copilot.ts
+++ b/packages/codemirror-copilot/src/copilot.ts
@@ -1,6 +1,11 @@
 import { inlineSuggestion } from "./inline-suggestion";
 import type { EditorState } from "@codemirror/state";
 
+/**
+ * Should fetch autosuggestions from your AI
+ * of choice. If there are no suggestions,
+ * you should return an empty string.
+ */
 export type SuggestionRequestCallback = (
   prefix: string,
   suffix: string
@@ -8,6 +13,11 @@ export type SuggestionRequestCallback = (
 
 const localSuggestionsCache: { [key: string]: string } = {};
 
+/**
+ * Configure the UI, state, and keymap to power
+ * auto suggestions, with an abstracted
+ * fetch method.
+ */
 export const inlineCopilot = (
   onSuggestionRequest: SuggestionRequestCallback,
   delay = 1000


### PR DESCRIPTION
For our somewhat picky uses, I think it'll be useful to have more granular exports and more options. To make all that work better, it'll be good to have some inline documentation. This adds some, for both public and important private methods.