### PR TITLE
Make onclick handler on suggestion optional

### DIFF
--- a/packages/codemirror-copilot/src/inline-suggestion.ts
+++ b/packages/codemirror-copilot/src/inline-suggestion.ts
@@ -10,6 +10,7 @@ import {
 import {
   StateEffect,
   Text,
+  Facet,
   Prec,
   StateField,
   EditorState,
@@ -17,6 +18,12 @@ import {
   TransactionSpec,
 } from "@codemirror/state";
 import { debouncePromise } from "./lib/utils";
+
+/**
+ * The inner method to fetch suggestions: this is
+ * abstracted by `inlineCopilot`.
+ */
+type InlineFetchFn = (state: EditorState) => Promise<string>;
 
 /**
  * Current state of the autosuggestion
@@ -48,60 +55,76 @@ const InlineSuggestionEffect = StateEffect.define<{
  * text to show what would be inserted if you accept
  * the AI suggestion.
  */
-function inlineSuggestionDecoration(view: EditorView, prefix: string) {
+function inlineSuggestionDecoration(view: EditorView, suggestionText: string) {
   const pos = view.state.selection.main.head;
   const widgets = [];
   const w = Decoration.widget({
-    widget: new InlineSuggestionWidget(prefix),
+    widget: new InlineSuggestionWidget(suggestionText),
     side: 1,
   });
   widgets.push(w.range(pos));
   return Decoration.set(widgets);
 }
 
+export const suggestionConfigFacet = Facet.define<
+  { acceptOnClick: boolean; fetchFn: InlineFetchFn },
+  { acceptOnClick: boolean; fetchFn: InlineFetchFn | undefined }
+>({
+  combine(value) {
+    return {
+      acceptOnClick: !!value.at(-1)?.acceptOnClick,
+      fetchFn: value.at(-1)?.fetchFn,
+    };
+  },
+});
+
+/**
+ * Renders the suggestion inline
+ * with the rest of the code in the editor.
+ */
 class InlineSuggestionWidget extends WidgetType {
   suggestion: string;
+
+  /**
+   * Create a new suggestion widget.
+   */
   constructor(suggestion: string) {
     super();
     this.suggestion = suggestion;
   }
   toDOM(view: EditorView) {
-    const div = document.createElement("span");
-    div.style.opacity = "0.4";
-    div.className = "cm-inline-suggestion";
-    div.textContent = this.suggestion;
-    div.onclick = (e) => {
-      e.stopPropagation();
-      e.preventDefault();
+    const span = document.createElement("span");
+    span.style.opacity = "0.4";
+    span.className = "cm-inline-suggestion";
+    span.textContent = this.suggestion;
+    span.onclick = (e) => this.accept(e, view);
+    return span;
+  }
+  accept(e: MouseEvent, view: EditorView) {
+    const config = view.state.facet(suggestionConfigFacet);
+    if (!config.acceptOnClick) return;
 
-      const suggestionText = view.state.field(
-        InlineSuggestionState
-      )?.suggestion;
+    e.stopPropagation();
+    e.preventDefault();
 
-      // If there is no suggestion, do nothing and let the default keymap handle it
-      if (!suggestionText) {
-        return false;
-      }
+    const suggestionText = view.state.field(InlineSuggestionState)?.suggestion;
 
-      view.dispatch({
-        ...insertCompletionText(
-          view.state,
-          suggestionText,
-          view.state.selection.main.head,
-          view.state.selection.main.head
-        ),
-      });
-      return true;
-    };
-    return div;
+    // If there is no suggestion, do nothing and let the default keymap handle it
+    if (!suggestionText) {
+      return false;
+    }
+
+    view.dispatch({
+      ...insertCompletionText(
+        view.state,
+        suggestionText,
+        view.state.selection.main.head,
+        view.state.selection.main.head
+      ),
+    });
+    return true;
   }
 }
-
-/**
- * The inner method to fetch suggestions: this is
- * abstracted by `inlineCopilot`.
- */
-type InlineFetchFn = (state: EditorState) => Promise<string>;
 
 /**
  * Listens to document updates and calls `fetchFn`
@@ -109,39 +132,45 @@ type InlineFetchFn = (state: EditorState) => Promise<string>;
  * `InlineSuggestionState` also being installed
  * in the editor’s extensions.
  */
-export const fetchSuggestion = (fetchFn: InlineFetchFn) =>
-  ViewPlugin.fromClass(
-    class Plugin {
-      async update(update: ViewUpdate) {
-        const doc = update.state.doc;
-        // Only fetch if the document has changed
-        if (!update.docChanged) {
-          return;
-        }
-
-        const isAutocompleted = update.transactions.some((t) =>
-          t.isUserEvent("input.complete")
-        );
-        if (isAutocompleted) {
-          return;
-        }
-        //   for (const tr of update.transactions) {
-        //     // Check the userEvent property of the transaction
-        //     if (tr.isUserEvent("input.complete")) {
-        //         console.log("Change was due to autocomplete");
-        //     } else {
-        //         console.log("Change was due to user input");
-        //     }
-        // }
-
-        // console.log("CH", update);
-        const result = await fetchFn(update.state);
-        update.view.dispatch({
-          effects: InlineSuggestionEffect.of({ text: result, doc: doc }),
-        });
+export const fetchSuggestion = ViewPlugin.fromClass(
+  class Plugin {
+    async update(update: ViewUpdate) {
+      const doc = update.state.doc;
+      // Only fetch if the document has changed
+      if (!update.docChanged) {
+        return;
       }
+
+      const isAutocompleted = update.transactions.some((t) =>
+        t.isUserEvent("input.complete")
+      );
+      if (isAutocompleted) {
+        return;
+      }
+      //   for (const tr of update.transactions) {
+      //     // Check the userEvent property of the transaction
+      //     if (tr.isUserEvent("input.complete")) {
+      //         console.log("Change was due to autocomplete");
+      //     } else {
+      //         console.log("Change was due to user input");
+      //     }
+      // }
+
+      // console.log("CH", update);
+      const config = update.view.state.facet(suggestionConfigFacet);
+      if (!config.fetchFn) {
+        console.error(
+          "Unexpected issue in codemirror-copilot: fetchFn was not configured"
+        );
+        return;
+      }
+      const result = await config.fetchFn(update.state);
+      update.view.dispatch({
+        effects: InlineSuggestionEffect.of({ text: result, doc: doc }),
+      });
     }
-  );
+  }
+);
 
 const renderInlineSuggestionPlugin = ViewPlugin.fromClass(
   class Plugin {
@@ -248,12 +277,18 @@ function insertCompletionText(
  * Options to configure the AI suggestion UI.
  */
 type InlineSuggestionOptions = {
-  fetchFn: (state: EditorState) => Promise<string>;
+  fetchFn: InlineFetchFn;
   /**
    * Delay after typing to query the API. A shorter
    * delay will query more often, and cost more.
    */
   delay?: number;
+
+  /**
+   * Whether clicking the suggestion will
+   * automatically accept it.
+   */
+  acceptOnClick?: boolean;
 };
 
 /**
@@ -261,11 +296,12 @@ type InlineSuggestionOptions = {
  * auto suggestions.
  */
 export function inlineSuggestion(options: InlineSuggestionOptions) {
-  const { delay = 500 } = options;
+  const { delay = 500, acceptOnClick = true } = options;
   const fetchFn = debouncePromise(options.fetchFn, delay);
   return [
+    suggestionConfigFacet.of({ acceptOnClick, fetchFn }),
     InlineSuggestionState,
-    fetchSuggestion(fetchFn),
+    fetchSuggestion,
     renderInlineSuggestionPlugin,
     inlineSuggestionKeymap,
   ];

--- a/website/components/editor.jsx
+++ b/website/components/editor.jsx
@@ -1,68 +1,106 @@
-import CodeMirror from '@uiw/react-codemirror';
-import { javascript } from '@codemirror/lang-javascript';
-import { dracula } from '@uiw/codemirror-theme-dracula';
+import CodeMirror from "@uiw/react-codemirror";
+import { javascript } from "@codemirror/lang-javascript";
+import { dracula } from "@uiw/codemirror-theme-dracula";
 
-import { inlineCopilot, clearLocalCache } from '../dist';
+import { inlineCopilot, clearLocalCache } from "../dist";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
-import { useState } from 'react';
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { useState } from "react";
 
-const DEFAULTCODE = 
-`function add(num1, num2){
+const DEFAULTCODE = `function add(num1, num2){
   ret
-}`
+}`;
 
 function CodeEditor() {
   const [model, setModel] = useState("gpt-3.5-turbo-1106");
+  const [acceptOnClick, setAcceptOnClick] = useState(true);
   return (
     <>
-    <Select value={model} onValueChange={(value)=>{
-      setModel(value);
-      clearLocalCache();
-    }}>
-  <SelectTrigger className="w-[180px]">
-    <SelectValue placeholder="Model" />
-  </SelectTrigger>
-  <SelectContent>
-    <SelectItem value="gpt-3.5-turbo-1106">GPT 3.5 Turbo <Badge variant="secondary">recommended</Badge></SelectItem>
-    <SelectItem value="codellama">Code Llama <Badge variant="secondary">buggy</Badge></SelectItem>
-    <SelectItem value="gpt-4-1106-preview">GPT-4 Turbo <Badge variant="destructive">expensive</Badge></SelectItem>
-  </SelectContent>
-</Select>
-    <CodeMirror
-      style={{ fontSize: "17px", width: "100%", borderRadius: "5px", overflow: "hidden", marginTop: "1rem" }}
-      value={DEFAULTCODE}
-      height="300px"
-      width="100%"
-      basicSetup={{
-        autocompletion: false,
-        lineNumbers: true,
-      }}
-      theme={dracula}
-      extensions={[
-        javascript({ jsx: true }),
-        inlineCopilot(async (prefix, suffix) => {
-          const res = await fetch('/api/autocomplete', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
+      <Select
+        value={model}
+        onValueChange={(value) => {
+          setModel(value);
+          clearLocalCache();
+        }}
+      >
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Model" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="gpt-3.5-turbo-1106">
+            GPT 3.5 Turbo <Badge variant="secondary">recommended</Badge>
+          </SelectItem>
+          <SelectItem value="codellama">
+            Code Llama <Badge variant="secondary">buggy</Badge>
+          </SelectItem>
+          <SelectItem value="gpt-4-1106-preview">
+            GPT-4 Turbo <Badge variant="destructive">expensive</Badge>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <CodeMirror
+        style={{
+          fontSize: "17px",
+          width: "100%",
+          borderRadius: "5px",
+          overflow: "hidden",
+          marginTop: "1rem",
+        }}
+        value={DEFAULTCODE}
+        height="300px"
+        width="100%"
+        basicSetup={{
+          autocompletion: false,
+          lineNumbers: true,
+        }}
+        theme={dracula}
+        extensions={[
+          javascript({ jsx: true }),
+          inlineCopilot(
+            async (prefix, suffix) => {
+              const res = await fetch("/api/autocomplete", {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  prefix,
+                  suffix,
+                  language: "javascript",
+                  model,
+                }),
+              });
+
+              const { prediction } = await res.json();
+              return prediction;
             },
-            body: JSON.stringify({ prefix, suffix, language: "javascript", model }),
-          });
-        
-          const { prediction } = await res.json();
-          return prediction;
-        }, 500)
-      ]}
-    />
+            500,
+            acceptOnClick,
+          ),
+        ]}
+      />
+      <div className="pt-2">
+        <label className="flex items-center gap-2">
+          <input
+            checked={acceptOnClick}
+            onChange={(e) => {
+              setAcceptOnClick(e.target.checked);
+            }}
+            type="checkbox"
+            name="click"
+          />
+          Clickable suggestions
+        </label>
+      </div>
     </>
   );
 }
 
 export default CodeEditor;
+


### PR DESCRIPTION
This does what it says on the tin - adds an option to make clicking the suggestion text optional. The rationale is essentially that a lot of users want their editor to be as VS Code-like as possible, and clicking Copilot suggestions in VS Code doesn't accept them. The default is still true, though, so this doesn't change default behavior.

In order to do this in a CodeMirror-like way, we're adding a configuration Facet and since we have that, why not use it for related configuration - the `fetchFn` is configured using the facet instead of a closure.