### PR TITLE
Add engines.node field to package.json

### DIFF
--- a/packages/codemirror-copilot/package.json
+++ b/packages/codemirror-copilot/package.json
@@ -41,5 +41,8 @@
   "peerDependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.2"
+  },
+  "engines": {
+    "node": "*"
   }
 }


### PR DESCRIPTION
Mostly this is just required to run `np`.