### PR TITLE
Don’t disappear if another plugin produces a transaction

### DIFF
--- a/packages/codemirror-copilot/src/inline-suggestion.ts
+++ b/packages/codemirror-copilot/src/inline-suggestion.ts
@@ -32,14 +32,22 @@ const InlineSuggestionState = StateField.define<{ suggestion: null | string }>({
   create() {
     return { suggestion: null };
   },
-  update(__, tr) {
+  update(previousValue, tr) {
     const inlineSuggestion = tr.effects.find((e) =>
       e.is(InlineSuggestionEffect),
     );
-    if (tr.state.doc)
+    if (tr.state.doc) {
       if (inlineSuggestion && tr.state.doc == inlineSuggestion.value.doc) {
+        // There is a new selection that has been set via an effect,
+        // and it applies to the current document.
         return { suggestion: inlineSuggestion.value.text };
+      } else if (!tr.docChanged && !tr.selection) {
+        // This transaction is irrelevant to the document state
+        // and could be generate by another plugin, so keep
+        // the previous value.
+        return previousValue;
       }
+    }
     return { suggestion: null };
   },
 });


### PR DESCRIPTION
We identified a race condition that can happen where you:

- Hit space, or another key, which triggers both an async linter in codemirror as well as codemirror-copilot
- Codemirror-copilot shows its inline suggestion
- The linter gets its results and applies its lints
- The transaction used by the linter to update its decorations/lints causes codemirror-copilot to hide

This PR is a safeguard around that: if there's a transaction that doesn't modify the selection or document, this lets codemirror-copilot keep its old value for its suggestion. This should help it play nice with other extensions.